### PR TITLE
Simplify is_public_ipv6 and improve readability.

### DIFF
--- a/bogons/bogons.py
+++ b/bogons/bogons.py
@@ -62,19 +62,18 @@ def is_public_ipv4(ip: ipaddress.IPv4Address) -> bool:
     return ip.is_global
 
 
-def is_public_ipv6(ip: ipaddress.IPv4Address) -> bool:
+def is_public_ipv6(ip: ipaddress.IPv6Address) -> bool:
     if ip.is_multicast:
         return False
-
-    ip_int = int(ip)
-    # 6to4 2002::/16
-    if ip_int >= 42545680458834377588178886921629466624 and ip_int <= 42550872755692912415807417417958686719:
+    
+    # 6to4 address space
+    if ip in ipaddress.IPv6Network('2002::16'):
         return False
-    # 6bone 3ffe::/16
-    if ip_int >= 85060207136517546210586590865283612672 and ip_int <= 85065399433376081038215121361612832767:
+    # 6bone address space
+    if ip in ipaddress.IPv6Network('3ffe::16'):
         return False
     # Anything else not in 2000::/3 is not public
-    if ip_int > 85070591730234615865843651857942052863:
+    if ip not in ipaddress.IPv6Network('2000::/3'):
         return False
 
     return ip.is_global

--- a/bogons/bogons.py
+++ b/bogons/bogons.py
@@ -67,7 +67,7 @@ def is_public_ipv6(ip: ipaddress.IPv6Address) -> bool:
         return False
     
     # 6to4 address space
-    if ip in ipaddress.IPv6Network('2002::16'):
+    if ip in ipaddress.IPv6Network('2002::/16'):
         return False
     # 6bone address space
     if ip in ipaddress.IPv6Network('3ffe::16'):

--- a/bogons/bogons.py
+++ b/bogons/bogons.py
@@ -70,7 +70,7 @@ def is_public_ipv6(ip: ipaddress.IPv6Address) -> bool:
     if ip in ipaddress.IPv6Network('2002::/16'):
         return False
     # 6bone address space
-    if ip in ipaddress.IPv6Network('3ffe::16'):
+    if ip in ipaddress.IPv6Network('3ffe::/16'):
         return False
     # Anything else not in 2000::/3 is not public
     if ip not in ipaddress.IPv6Network('2000::/3'):

--- a/bogons_test.py
+++ b/bogons_test.py
@@ -52,5 +52,5 @@ class valid_public_asnTest(unittest.TestCase):
         self.assertEqual(bogons.is_public_ip("4600::"), False)
         self.assertEqual(bogons.is_public_ip(""), False)
 
-    if __name__ == '__main__':
-        unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/bogons_test.py
+++ b/bogons_test.py
@@ -51,3 +51,6 @@ class valid_public_asnTest(unittest.TestCase):
         self.assertEqual(bogons.is_public_ip("3fff:::"), False)
         self.assertEqual(bogons.is_public_ip("4600::"), False)
         self.assertEqual(bogons.is_public_ip(""), False)
+
+    if __name__ == '__main__':
+        unittest.main()


### PR DESCRIPTION
1. Use ipaddress module builtins for comparing networks and addresses.
2. Fix typo for is_public_ipv6 fiunction argument.
3. Add main call for the unit test module.